### PR TITLE
fix(gemini): Fix Google Gemini API field naming to use camelCase

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerationConfig.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerationConfig.java
@@ -7,52 +7,51 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 class GeminiGenerationConfig {
 
-    @JsonProperty
+    @JsonProperty("stopSequences")
     private final List<String> stopSequences;
 
-    @JsonProperty
+    @JsonProperty("responseMimeType")
     private final String responseMimeType;
 
-    @JsonProperty
+    @JsonProperty("responseSchema")
     private final GeminiSchema responseSchema;
 
-    @JsonProperty
+    @JsonProperty("candidateCount")
     private final Integer candidateCount;
 
-    @JsonProperty
+    @JsonProperty("maxOutputTokens")
     private final Integer maxOutputTokens;
 
-    @JsonProperty
+    @JsonProperty("temperature")
     private final Double temperature;
 
-    @JsonProperty
+    @JsonProperty("topK")
     private final Integer topK;
 
-    @JsonProperty
+    @JsonProperty("seed")
     private Integer seed;
 
-    @JsonProperty
+    @JsonProperty("topP")
     private final Double topP;
 
-    @JsonProperty
+    @JsonProperty("presencePenalty")
     private final Double presencePenalty;
 
-    @JsonProperty
+    @JsonProperty("frequencyPenalty")
     private final Double frequencyPenalty;
 
-    @JsonProperty
+    @JsonProperty("thinkingConfig")
     private final GeminiThinkingConfig thinkingConfig;
 
-    @JsonProperty
+    @JsonProperty("responseLogprobs")
     private final Boolean responseLogprobs;
 
-    @JsonProperty
+    @JsonProperty("enableEnhancedCivicAnswers")
     private final Boolean enableEnhancedCivicAnswers;
 
-    @JsonProperty
+    @JsonProperty("logprobs")
     private final Integer logprobs;
 
     GeminiGenerationConfig(GeminiGenerationConfigBuilder builder) {

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiThinkingConfig.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiThinkingConfig.java
@@ -6,12 +6,10 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GeminiThinkingConfig {
-
-    @JsonProperty
+    @JsonProperty("includeThoughts")
     private Boolean includeThoughts;
-    @JsonProperty
+    @JsonProperty("thinkingBudget")
     private Integer thinkingBudget;
 
     private GeminiThinkingConfig(Builder builder) {


### PR DESCRIPTION
## Issue
Fixes #3559

## Change
Fixed Google Gemini API field naming compatibility issue by removing snake_case naming strategy and using camelCase field names as required by the official Google Gemini API specification.

**Changes made:**
- Removed `@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)` annotation from `GeminiGenerationConfig` and `GeminiThinkingConfig` classes
- Added explicit camelCase field names in `@JsonProperty` annotations for all existing fields in both classes

**Root cause:**
The snake_case naming strategy was causing JSON fields to be serialized as `thinking_config`, `include_thoughts`, `thinking_budget`, `response_mime_type`, etc., but Google Gemini API expects `thinkingConfig`, `includeThoughts`, `thinkingBudget`, `responseMimeType`, etc. This caused important configuration parameters like thinking functionality to be silently ignored by the API.

**Impact:**
- Fixes thinking functionality not working due to incorrect field naming
- Ensures all generation config parameters are properly recognized by Google Gemini API
- No breaking changes to the public API - only internal JSON serialization is affected

## General checklist
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
